### PR TITLE
NoChunkHandling mode

### DIFF
--- a/src/httpserver/qabstracthttpserver.h
+++ b/src/httpserver/qabstracthttpserver.h
@@ -33,12 +33,12 @@
 #include <QtCore/qobject.h>
 
 #include <QtHttpServer/qthttpserverglobal.h>
+#include <QtHttpServer/qhttpserverrequest.h>
 
 #include <QtNetwork/qhostaddress.h>
 
 QT_BEGIN_NAMESPACE
 
-class QHttpServerRequest;
 class QHttpServerResponder;
 class QTcpServer;
 class QTcpSocket;
@@ -56,6 +56,8 @@ public:
 
     void bind(QTcpServer *server = nullptr);
     QVector<QTcpServer *> servers() const;
+
+    void setRequestsOptions(const QHttpServerRequest::Options &options);
 
 Q_SIGNALS:
     void missingHandler(const QHttpServerRequest &request, QTcpSocket *socket);

--- a/src/httpserver/qabstracthttpserver_p.h
+++ b/src/httpserver/qabstracthttpserver_p.h
@@ -70,6 +70,8 @@ public:
     void handleNewConnections();
     void handleReadyRead(QTcpSocket *socket,
                          QHttpServerRequest *request);
+
+    QHttpServerRequest::Options requestsOptions;
 };
 
 QT_END_NAMESPACE

--- a/src/httpserver/qhttpserverrequest.cpp
+++ b/src/httpserver/qhttpserverrequest.cpp
@@ -223,6 +223,7 @@ int QHttpServerRequestPrivate::onBody(http_parser *httpParser, const char *at, s
         i->state = State::OnChunkBody;
         i->body.setRawData(at, uint(length)); // no allocation required
         i->chunkBodyHandler();
+        i->body.clear();
     } else {
         i->state = State::OnBody;
         if (i->body.isEmpty()) {

--- a/src/httpserver/qhttpserverrequest.h
+++ b/src/httpserver/qhttpserverrequest.h
@@ -81,12 +81,29 @@ public:
     Q_DECLARE_FLAGS(Methods, Method)
     Q_FLAG(Methods)
 
+    enum Option {
+        NoneOption          = 0x0000,
+        NoChunkHandling     = 0x0001,
+    };
+    Q_ENUM(Option)
+    Q_DECLARE_FLAGS(Options, Option)
+    Q_FLAG(Options)
+
+    enum BodyType {
+        Undefined,
+        Complete,
+        Chunk,
+        LastChunk
+    };
+    Q_ENUM(BodyType)
+
     QByteArray value(const QByteArray &key) const;
     QUrl url() const;
     QUrlQuery query() const;
     Method method() const;
     QVariantMap headers() const;
     QByteArray body() const;
+    BodyType bodyType() const;
     QHostAddress remoteAddress() const;
 
 protected:
@@ -96,8 +113,7 @@ private:
 #if !defined(QT_NO_DEBUG_STREAM)
     friend Q_HTTPSERVER_EXPORT QDebug operator<<(QDebug debug, const QHttpServerRequest &request);
 #endif
-
-    explicit QHttpServerRequest(const QHostAddress &remoteAddress);
+    explicit QHttpServerRequest(const QHostAddress &remoteAddress, const Options &options);
 
     QHttpServerRequestPrivate *d = nullptr;
 };

--- a/src/httpserver/qhttpserverrequest_p.h
+++ b/src/httpserver/qhttpserverrequest_p.h
@@ -57,7 +57,7 @@ QT_BEGIN_NAMESPACE
 class QHttpServerRequestPrivate : public QSharedData
 {
 public:
-    QHttpServerRequestPrivate(const QHostAddress &remoteAddress);
+    QHttpServerRequestPrivate(const QHostAddress &remoteAddress, const QHttpServerRequest::Options &options);
 
     quint16 port = 0;
     enum class State {
@@ -68,7 +68,9 @@ public:
         OnHeaders,
         OnHeadersComplete,
         OnBody,
+        OnChunkBody,
         OnMessageComplete,
+        OnChunkMessageComplete,
         OnChunkHeader,
         OnChunkComplete
     } state = State::NotStarted;
@@ -88,6 +90,9 @@ public:
 
     void clear();
     QHostAddress remoteAddress;
+    QHttpServerRequest::Options options;
+
+    std::function<void()> chunkBodyHandler;
 
 private:
     static http_parser_settings httpParserSettings;


### PR DESCRIPTION
> Allow route handler to handle directly data chunks within a chunked request

- add QHttpServerRequest::Options flags
- add NoChunkHandling optional mode in QHttpServerRequest::Options
- add setRequestsOption method in QAbstractHttpServer
- add BodyType enum with Complete, Chunk and LastChunk values