### PR TITLE
Feature/iodevice body

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,4 +52,7 @@ add_library(Qt5::HttpServer ALIAS ${PROJECT_NAME})
 execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink ${PROJECT_SOURCE_DIR}/src/httpserver ${PROJECT_BINARY_DIR}/QtHttpServer)
 execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink ${PROJECT_SOURCE_DIR}/src/httpserver ${PROJECT_BINARY_DIR}/private)
 
-add_subdirectory(tests)
+option(QTHTTPSERVER_TESTS_EN "Qt http server test enabled" OFF)
+if (QTHTTPSERVER_TESTS_EN)
+    add_subdirectory(tests)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,47 @@
+cmake_minimum_required(VERSION 3.7)
+
+project(qthttpserver)
+
+find_package(Qt5 COMPONENTS Core Network REQUIRED)
+
+add_library(${PROJECT_NAME} STATIC
+    src/3rdparty/http-parser/http_parser.h
+    src/3rdparty/http-parser/http_parser.c
+
+    src/httpserver/qthttpserverglobal.h
+    src/httpserver/qabstracthttpserver.h
+    src/httpserver/qabstracthttpserver_p.h
+    src/httpserver/qhttpserver.h
+    src/httpserver/qhttpserver_p.h
+    src/httpserver/qhttpserverrequest.h
+    src/httpserver/qhttpserverrequest_p.h
+    src/httpserver/qhttpserverresponder.h
+    src/httpserver/qhttpserverresponder_p.h
+    src/httpserver/qhttpserverresponse.h
+    src/httpserver/qhttpserverresponse_p.h
+    src/httpserver/qhttpserverrouter.h
+    src/httpserver/qhttpserverrouter_p.h
+    src/httpserver/qhttpserverrouterrule.h
+    src/httpserver/qhttpserverrouterrule_p.h
+    src/httpserver/qhttpserverrouterviewtraits.h
+    src/httpserver/qhttpserverliterals_p.h
+
+    src/httpserver/qabstracthttpserver.cpp
+    src/httpserver/qhttpserver.cpp
+    src/httpserver/qhttpserverrequest.cpp
+    src/httpserver/qhttpserverresponder.cpp
+    src/httpserver/qhttpserverresponse.cpp
+    src/httpserver/qhttpserverrouter.cpp
+    src/httpserver/qhttpserverrouterrule.cpp
+    src/httpserver/qhttpserverliterals.cpp
+)
+target_link_libraries(${PROJECT_NAME} PUBLIC Qt5::Core Qt5::Network)
+target_include_directories(${PROJECT_NAME} PUBLIC ${PROJECT_BINARY_DIR})
+target_include_directories(${PROJECT_NAME} PRIVATE
+    ${Qt5Core_PRIVATE_INCLUDE_DIRS}
+    ${Qt5Network_PRIVATE_INCLUDE_DIRS}
+    src/3rdparty/http-parser
+)
+add_library(Qt5::HttpServer ALIAS ${PROJECT_NAME})
+execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink ${PROJECT_SOURCE_DIR}/src/httpserver ${PROJECT_BINARY_DIR}/QtHttpServer)
+execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink ${PROJECT_SOURCE_DIR}/src/httpserver ${PROJECT_BINARY_DIR}/private)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required(VERSION 3.7)
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,9 @@
 cmake_minimum_required(VERSION 3.7)
 
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
 project(qthttpserver)
 
 find_package(Qt5 COMPONENTS Core Network REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,5 +43,9 @@ target_include_directories(${PROJECT_NAME} PRIVATE
     src/3rdparty/http-parser
 )
 add_library(Qt5::HttpServer ALIAS ${PROJECT_NAME})
+
+# emulate qt folders
 execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink ${PROJECT_SOURCE_DIR}/src/httpserver ${PROJECT_BINARY_DIR}/QtHttpServer)
 execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink ${PROJECT_SOURCE_DIR}/src/httpserver ${PROJECT_BINARY_DIR}/private)
+
+add_subdirectory(tests)

--- a/src/httpserver/httpserver.pro
+++ b/src/httpserver/httpserver.pro
@@ -4,6 +4,7 @@ INCLUDEPATH += .
 QT = network core-private
 
 qtHaveModule(websockets): QT += websockets-private
+qtConfig(ssl): QT += sslserver
 
 HEADERS += \
     qthttpserverglobal.h \

--- a/src/httpserver/qabstracthttpserver.cpp
+++ b/src/httpserver/qabstracthttpserver.cpp
@@ -48,8 +48,7 @@ QT_BEGIN_NAMESPACE
 
 Q_LOGGING_CATEGORY(lcHttpServer, "qt.httpserver")
 
-QAbstractHttpServerPrivate::QAbstractHttpServerPrivate(QAbstractHttpServer* server):
-    server(server)
+QAbstractHttpServerPrivate::QAbstractHttpServerPrivate()
 {
 }
 
@@ -59,7 +58,7 @@ void QAbstractHttpServerPrivate::handleNewConnections()
     auto tcpServer = qobject_cast<QTcpServer *>(q->sender());
     Q_ASSERT(tcpServer);
     while (auto socket = tcpServer->nextPendingConnection()) {
-        auto request = new QHttpServerRequest(socket->peerAddress(), this->server);  // TODO own tcp server could pre-allocate it
+        auto request = new QHttpServerRequest(socket->peerAddress(), q);  // TODO own tcp server could pre-allocate it
         http_parser_init(&request->d->httpParser, HTTP_REQUEST);
 
         QObject::connect(socket, &QTcpSocket::readyRead, q_ptr,
@@ -134,7 +133,7 @@ QIODevice* QAbstractHttpServer::createBodyDevice(const QHttpServerRequest& /*req
 }
 
 QAbstractHttpServer::QAbstractHttpServer(QObject *parent)
-    : QAbstractHttpServer(*new QAbstractHttpServerPrivate(this), parent)
+    : QAbstractHttpServer(*new QAbstractHttpServerPrivate(), parent)
 {}
 
 QAbstractHttpServer::QAbstractHttpServer(QAbstractHttpServerPrivate &dd, QObject *parent)

--- a/src/httpserver/qabstracthttpserver.h
+++ b/src/httpserver/qabstracthttpserver.h
@@ -36,6 +36,12 @@
 
 #include <QtNetwork/qhostaddress.h>
 
+#if QT_CONFIG(ssl)
+#include <QtSslServer/qsslserver.h>
+#include <QSslCertificate>
+#include <QSslKey>
+#endif
+
 QT_BEGIN_NAMESPACE
 
 class QHttpServerRequest;
@@ -56,6 +62,12 @@ public:
 
     void bind(QTcpServer *server = nullptr);
     QVector<QTcpServer *> servers() const;
+
+#if QT_CONFIG(ssl)
+    void sslSetup(const QSslCertificate &certificate, const QSslKey &privateKey,
+                  QSsl::SslProtocol protocol = QSsl::SecureProtocols);
+    void sslSetup(const QSslConfiguration &sslConfiguration);
+#endif
 
 Q_SIGNALS:
     void missingHandler(const QHttpServerRequest &request, QTcpSocket *socket);

--- a/src/httpserver/qabstracthttpserver.h
+++ b/src/httpserver/qabstracthttpserver.h
@@ -67,6 +67,10 @@ public:
     void sslSetup(const QSslCertificate &certificate, const QSslKey &privateKey,
                   QSsl::SslProtocol protocol = QSsl::SecureProtocols);
     void sslSetup(const QSslConfiguration &sslConfiguration);
+
+    Q_SIGNAL void sslErrors(QList<QSslError> errors);
+    void ignoreSslErrors();
+    void ignoreSslErrors(const QList<QSslError>& errors);
 #endif
 
 Q_SIGNALS:

--- a/src/httpserver/qabstracthttpserver.h
+++ b/src/httpserver/qabstracthttpserver.h
@@ -87,8 +87,11 @@ protected:
     static QHttpServerResponder makeResponder(const QHttpServerRequest &request,
                                               QTcpSocket *socket);
 
+    virtual QIODevice* createBodyDevice(const QHttpServerRequest& request);
+
 private:
     Q_DECLARE_PRIVATE(QAbstractHttpServer)
+    friend class QHttpServerRequestPrivate;
 };
 
 QT_END_NAMESPACE

--- a/src/httpserver/qabstracthttpserver_p.h
+++ b/src/httpserver/qabstracthttpserver_p.h
@@ -58,7 +58,7 @@ class Q_HTTPSERVER_EXPORT QAbstractHttpServerPrivate: public QObjectPrivate
     Q_DECLARE_PUBLIC(QAbstractHttpServer)
 
 public:
-    QAbstractHttpServerPrivate(QAbstractHttpServer* server);
+    QAbstractHttpServerPrivate();
 
 #if defined(QT_WEBSOCKETS_LIB)
     QWebSocketServer websocketServer {
@@ -75,9 +75,6 @@ public:
     QSslConfiguration sslConfiguration;
     bool sslEnabled = false;
 #endif
-
-private:
-    QAbstractHttpServer * server;
 };
 
 QT_END_NAMESPACE

--- a/src/httpserver/qabstracthttpserver_p.h
+++ b/src/httpserver/qabstracthttpserver_p.h
@@ -58,7 +58,7 @@ class Q_HTTPSERVER_EXPORT QAbstractHttpServerPrivate: public QObjectPrivate
     Q_DECLARE_PUBLIC(QAbstractHttpServer)
 
 public:
-    QAbstractHttpServerPrivate();
+    QAbstractHttpServerPrivate(QAbstractHttpServer* server);
 
 #if defined(QT_WEBSOCKETS_LIB)
     QWebSocketServer websocketServer {
@@ -75,6 +75,9 @@ public:
     QSslConfiguration sslConfiguration;
     bool sslEnabled = false;
 #endif
+
+private:
+    QAbstractHttpServer * server;
 };
 
 QT_END_NAMESPACE

--- a/src/httpserver/qabstracthttpserver_p.h
+++ b/src/httpserver/qabstracthttpserver_p.h
@@ -73,7 +73,9 @@ public:
 
 #if QT_CONFIG(ssl)
     QSslConfiguration sslConfiguration;
+    QList<QSslError> ignoreSslErrorList;
     bool sslEnabled = false;
+    bool ignoreAllSslErrors = false;
 #endif
 };
 

--- a/src/httpserver/qhttpserver.cpp
+++ b/src/httpserver/qhttpserver.cpp
@@ -126,10 +126,7 @@ void QHttpServer::sendResponse(const QHttpServerResponse &response,
                                const QHttpServerRequest &request,
                                QTcpSocket *socket)
 {
-    auto responder = makeResponder(request, socket);
-    responder.write(response.data(),
-                    response.mimeType(),
-                    response.statusCode());
+    response.write(makeResponder(request, socket));
 }
 
 /*!

--- a/src/httpserver/qhttpserver.cpp
+++ b/src/httpserver/qhttpserver.cpp
@@ -44,10 +44,6 @@ QT_BEGIN_NAMESPACE
 
 Q_LOGGING_CATEGORY(lcHS, "qt.httpserver");
 
-QHttpServerPrivate::QHttpServerPrivate(QAbstractHttpServer* server):
-    QAbstractHttpServerPrivate(server)
-{}
-
 /*!
     \class QHttpServer
     \brief QHttpServer is a simplified API for QAbstractHttpServer and QHttpServerRouter.
@@ -65,7 +61,7 @@ QHttpServerPrivate::QHttpServerPrivate(QAbstractHttpServer* server):
 */
 
 QHttpServer::QHttpServer(QObject *parent)
-    : QAbstractHttpServer(*new QHttpServerPrivate(this), parent)
+    : QAbstractHttpServer(*new QHttpServerPrivate(), parent)
 {
     connect(this, &QAbstractHttpServer::missingHandler, this,
             [=] (const QHttpServerRequest &request, QTcpSocket *socket) {

--- a/src/httpserver/qhttpserver.cpp
+++ b/src/httpserver/qhttpserver.cpp
@@ -44,6 +44,10 @@ QT_BEGIN_NAMESPACE
 
 Q_LOGGING_CATEGORY(lcHS, "qt.httpserver");
 
+QHttpServerPrivate::QHttpServerPrivate(QAbstractHttpServer* server):
+    QAbstractHttpServerPrivate(server)
+{}
+
 /*!
     \class QHttpServer
     \brief QHttpServer is a simplified API for QAbstractHttpServer and QHttpServerRouter.
@@ -61,7 +65,7 @@ Q_LOGGING_CATEGORY(lcHS, "qt.httpserver");
 */
 
 QHttpServer::QHttpServer(QObject *parent)
-    : QAbstractHttpServer(*new QHttpServerPrivate, parent)
+    : QAbstractHttpServer(*new QHttpServerPrivate(this), parent)
 {
     connect(this, &QAbstractHttpServer::missingHandler, this,
             [=] (const QHttpServerRequest &request, QTcpSocket *socket) {
@@ -136,6 +140,11 @@ bool QHttpServer::handleRequest(const QHttpServerRequest &request, QTcpSocket *s
 {
     Q_D(QHttpServer);
     return d->router.handleRequest(request, socket);
+}
+
+QIODevice* QHttpServer::createBodyDevice(const QHttpServerRequest& request) {
+    Q_D(QHttpServer);
+    return d->router.createBodyDevice(request);
 }
 
 QT_END_NAMESPACE

--- a/src/httpserver/qhttpserver.h
+++ b/src/httpserver/qhttpserver.h
@@ -44,7 +44,7 @@ class QTcpSocket;
 class QHttpServerRequest;
 
 class QHttpServerPrivate;
-class Q_HTTPSERVER_EXPORT QHttpServer final : public QAbstractHttpServer
+class Q_HTTPSERVER_EXPORT QHttpServer : public QAbstractHttpServer
 {
     Q_OBJECT
     Q_DECLARE_PRIVATE(QHttpServer)
@@ -59,7 +59,7 @@ class Q_HTTPSERVER_EXPORT QHttpServer final : public QAbstractHttpServer
 
 public:
     explicit QHttpServer(QObject *parent = nullptr);
-    ~QHttpServer();
+    virtual ~QHttpServer() Q_DECL_OVERRIDE;
 
     QHttpServerRouter *router();
 

--- a/src/httpserver/qhttpserver.h
+++ b/src/httpserver/qhttpserver.h
@@ -75,6 +75,9 @@ public:
                 std::forward<Args>(args)...);
     }
 
+protected:
+    QIODevice* createBodyDevice(const QHttpServerRequest& request) override;
+
 private:
     template<typename Rule, typename ViewHandler, typename ViewTraits, int ... I, typename ... Args>
     bool routeHelper(QtPrivate::IndexesList<I...>, Args &&... args)

--- a/src/httpserver/qhttpserver_p.h
+++ b/src/httpserver/qhttpserver_p.h
@@ -56,7 +56,7 @@ class QHttpServerPrivate: public QAbstractHttpServerPrivate
     Q_DECLARE_PUBLIC(QHttpServer)
 
 public:
-    QHttpServerPrivate() = default;
+    QHttpServerPrivate(QAbstractHttpServer* server);
 
     QHttpServerRouter router;
 };

--- a/src/httpserver/qhttpserver_p.h
+++ b/src/httpserver/qhttpserver_p.h
@@ -56,7 +56,7 @@ class QHttpServerPrivate: public QAbstractHttpServerPrivate
     Q_DECLARE_PUBLIC(QHttpServer)
 
 public:
-    QHttpServerPrivate(QAbstractHttpServer* server);
+    QHttpServerPrivate() = default;
 
     QHttpServerRouter router;
 };

--- a/src/httpserver/qhttpserverrequest.cpp
+++ b/src/httpserver/qhttpserverrequest.cpp
@@ -136,8 +136,11 @@ void QHttpServerRequestPrivate::clear()
     url.clear();
     lastHeader.clear();
     headers.clear();
-    if (bodyDevice && bodyDevice->isOpen()) {
-        bodyDevice->close();
+    if (bodyDevice) {
+        if (bodyDevice->isOpen())
+            bodyDevice->close();
+        bodyDevice->deleteLater();
+        bodyDevice = nullptr;
     }
 }
 

--- a/src/httpserver/qhttpserverrequest.cpp
+++ b/src/httpserver/qhttpserverrequest.cpp
@@ -119,7 +119,7 @@ bool QHttpServerRequestPrivate::parse(QIODevice *socket)
                                                 fragment.constData(),
                                                 size_t(fragment.size()));
         if (int(parsed) < fragment.size()) {
-            qCDebug(lc, "Parse error: %d", httpParser.http_errno);
+            qCDebug(lc, "Parse error: %s", http_errno_description(static_cast<http_errno>(httpParser.http_errno)));
             return false;
         }
     }

--- a/src/httpserver/qhttpserverrequest.h
+++ b/src/httpserver/qhttpserverrequest.h
@@ -99,7 +99,7 @@ private:
 
     explicit QHttpServerRequest(const QHostAddress &remoteAddress);
 
-    QHttpServerRequestPrivate *d = nullptr;
+    QSharedPointer<QHttpServerRequestPrivate> d;
 };
 
 QT_END_NAMESPACE

--- a/src/httpserver/qhttpserverrequest.h
+++ b/src/httpserver/qhttpserverrequest.h
@@ -45,6 +45,8 @@ class QString;
 class QTcpSocket;
 
 class QHttpServerRequestPrivate;
+class QAbstractHttpServer;
+
 class Q_HTTPSERVER_EXPORT QHttpServerRequest
 {
     friend class QAbstractHttpServerPrivate;
@@ -86,6 +88,7 @@ public:
     QUrlQuery query() const;
     Method method() const;
     QVariantMap headers() const;
+    QIODevice* bodyDevice() const;
     QByteArray body() const;
     QHostAddress remoteAddress() const;
 
@@ -97,7 +100,7 @@ private:
     friend Q_HTTPSERVER_EXPORT QDebug operator<<(QDebug debug, const QHttpServerRequest &request);
 #endif
 
-    explicit QHttpServerRequest(const QHostAddress &remoteAddress);
+    explicit QHttpServerRequest(const QHostAddress &remoteAddress, QAbstractHttpServer* server);
 
     QSharedPointer<QHttpServerRequestPrivate> d;
 };

--- a/src/httpserver/qhttpserverrequest_p.h
+++ b/src/httpserver/qhttpserverrequest_p.h
@@ -54,10 +54,13 @@
 
 QT_BEGIN_NAMESPACE
 
+class QAbstractHttpServer;
+
 class QHttpServerRequestPrivate : public QSharedData
 {
 public:
-    QHttpServerRequestPrivate(const QHostAddress &remoteAddress);
+    QHttpServerRequestPrivate(const QHostAddress &remoteAddress, QAbstractHttpServer* server, QHttpServerRequest* request);
+    ~QHttpServerRequestPrivate();
 
     quint16 port = 0;
     enum class State {
@@ -72,7 +75,7 @@ public:
         OnChunkHeader,
         OnChunkComplete
     } state = State::NotStarted;
-    QByteArray body;
+    QIODevice* bodyDevice;
 
     QUrl url;
 
@@ -90,6 +93,9 @@ public:
     QHostAddress remoteAddress;
 
 private:
+    QAbstractHttpServer* server;
+    QHttpServerRequest* request;
+
     static http_parser_settings httpParserSettings;
     static bool parseUrl(const char *at, size_t length, bool connect, QUrl *url);
 

--- a/src/httpserver/qhttpserverresponse.h
+++ b/src/httpserver/qhttpserverresponse.h
@@ -86,8 +86,44 @@ public:
     QByteArray mimeType() const;
 
     StatusCode statusCode() const;
+
+    void addHeader(QByteArray &&name, QByteArray &&value);
+    void addHeader(QByteArray &&name, const QByteArray &value);
+    void addHeader(const QByteArray &name, QByteArray &&value);
+    void addHeader(const QByteArray &name, const QByteArray &value);
+
+    void addHeaders(QHttpServerResponder::HeaderList headers);
+
+    template<typename Container>
+    void addHeaders(const Container &headers)
+    {
+        for (const auto &header : headers)
+            addHeader(header.first, header.second);
+    }
+
+    void clearHeader(const QByteArray &name);
+    void clearHeaders();
+
+    void setHeader(QByteArray &&name, QByteArray &&value);
+    void setHeader(QByteArray &&name, const QByteArray &value);
+    void setHeader(const QByteArray &name, QByteArray &&value);
+    void setHeader(const QByteArray &name, const QByteArray &value);
+
+    void setHeaders(QHttpServerResponder::HeaderList headers);
+
+    bool hasHeader(const QByteArray &name) const;
+    bool hasHeader(const QByteArray &name, const QByteArray &value) const;
+
+    QVector<QByteArray> headers(const QByteArray &name) const;
+
+    virtual void write(QHttpServerResponder &&responder) const;
+
 private:
-    QHttpServerResponse(QHttpServerResponsePrivate *d);
+    QHttpServerResponse(const QByteArray &mimeType,
+                        QHttpServerResponsePrivate *d);
+
+    QHttpServerResponse(QByteArray &&mimeType,
+                        QHttpServerResponsePrivate *d);
 
     QScopedPointer<QHttpServerResponsePrivate> d_ptr;
 };

--- a/src/httpserver/qhttpserverresponse_p.h
+++ b/src/httpserver/qhttpserverresponse_p.h
@@ -44,14 +44,25 @@
 
 #include <QtHttpServer/qhttpserverresponse.h>
 
+#include <functional>
+#include <unordered_map>
+
 QT_BEGIN_NAMESPACE
 
 class QHttpServerResponsePrivate
 {
+    struct HashHelper {
+        std::size_t operator()(const QByteArray& key) const
+        {
+            return qHash(key.toLower());
+        }
+    };
+
 public:
-    QByteArray mimeType;
     QByteArray data;
     QHttpServerResponse::StatusCode statusCode;
+
+    std::unordered_multimap<QByteArray, QByteArray, HashHelper> headers;
 };
 
 QT_END_NAMESPACE

--- a/src/httpserver/qhttpserverrouter.cpp
+++ b/src/httpserver/qhttpserverrouter.cpp
@@ -315,7 +315,7 @@ QIODevice* QHttpServerRouter::createBodyDevice(const QHttpServerRequest &request
         QRegularExpressionMatch match;
         if (!rule->matches(request, &match))
             continue;
-        QIODevice * device = rule->createBodyDevice(match);
+        QIODevice * device = rule->createBodyDevice(request, match);
         if (device != nullptr)
             return device;
     }

--- a/src/httpserver/qhttpserverrouter.cpp
+++ b/src/httpserver/qhttpserverrouter.cpp
@@ -309,4 +309,17 @@ bool QHttpServerRouter::handleRequest(const QHttpServerRequest &request,
     return false;
 }
 
+QIODevice* QHttpServerRouter::createBodyDevice(const QHttpServerRequest &request) {
+    Q_D(const QHttpServerRouter);
+    for (const auto &rule : qAsConst(d->rules)) {
+        QRegularExpressionMatch match;
+        if (!rule->matches(request, &match))
+            continue;
+        QIODevice * device = rule->createBodyDevice(match);
+        if (device != nullptr)
+            return device;
+    }
+    return nullptr;
+}
+
 QT_END_NAMESPACE

--- a/src/httpserver/qhttpserverrouter.h
+++ b/src/httpserver/qhttpserverrouter.h
@@ -32,10 +32,12 @@
 
 #include <QtHttpServer/qthttpserverglobal.h>
 #include <QtHttpServer/qhttpserverrouterviewtraits.h>
+#include <QtHttpServer/qhttpserverrouterrule.h>
 
 #include <QtCore/qscopedpointer.h>
 #include <QtCore/qmetatype.h>
 #include <QtCore/qregularexpression.h>
+#include <QtCore/qbuffer.h>
 
 #include <functional>
 #include <initializer_list>
@@ -113,6 +115,8 @@ public:
 
     bool handleRequest(const QHttpServerRequest &request,
                        QTcpSocket *socket) const;
+
+    QIODevice* createBodyDevice(const QHttpServerRequest &request);
 
 private:
     template<typename ViewTraits, int ... Idx>

--- a/src/httpserver/qhttpserverrouterrule.cpp
+++ b/src/httpserver/qhttpserverrouterrule.cpp
@@ -223,7 +223,10 @@ bool QHttpServerRouterRule::matches(const QHttpServerRequest &request,
     return (match->hasMatch() && d->pathRegexp.captureCount() == match->lastCapturedIndex());
 }
 
-QIODevice* QHttpServerRouterRule::createBodyDevice(const QRegularExpressionMatch& /*match*/) {
+/*!
+    This virtual function is called by QHttpServer::createBodyDevice to get the device associated to this rule.
+ */
+QIODevice* QHttpServerRouterRule::createBodyDevice(const QHttpServerRequest &/*request*/, const QRegularExpressionMatch &/*match*/) {
     return new QBuffer();
 }
 

--- a/src/httpserver/qhttpserverrouterrule.cpp
+++ b/src/httpserver/qhttpserverrouterrule.cpp
@@ -37,6 +37,8 @@
 #include <QtCore/qregularexpression.h>
 #include <QtCore/qdebug.h>
 
+#include <QtCore/qstringbuilder.h>
+
 QT_BEGIN_NAMESPACE
 
 Q_LOGGING_CATEGORY(lcRouterRule, "qt.httpserver.router.rule")

--- a/src/httpserver/qhttpserverrouterrule.cpp
+++ b/src/httpserver/qhttpserverrouterrule.cpp
@@ -37,6 +37,7 @@
 #include <QtCore/qregularexpression.h>
 #include <QtCore/qdebug.h>
 
+#include <QtCore/qbuffer.h>
 #include <QtCore/qstringbuilder.h>
 
 QT_BEGIN_NAMESPACE
@@ -220,6 +221,10 @@ bool QHttpServerRouterRule::matches(const QHttpServerRequest &request,
 
     *match = d->pathRegexp.match(request.url().path());
     return (match->hasMatch() && d->pathRegexp.captureCount() == match->lastCapturedIndex());
+}
+
+QIODevice* QHttpServerRouterRule::createBodyDevice(const QRegularExpressionMatch& /*match*/) {
+    return new QBuffer();
 }
 
 /*!

--- a/src/httpserver/qhttpserverrouterrule.h
+++ b/src/httpserver/qhttpserverrouterrule.h
@@ -76,6 +76,8 @@ protected:
     virtual bool matches(const QHttpServerRequest &request,
                          QRegularExpressionMatch *match) const;
 
+    virtual QIODevice* createBodyDevice(const QRegularExpressionMatch& match);
+
     QHttpServerRouterRule(QHttpServerRouterRulePrivate *d);
 
 private:

--- a/src/httpserver/qhttpserverrouterrule.h
+++ b/src/httpserver/qhttpserverrouterrule.h
@@ -76,7 +76,7 @@ protected:
     virtual bool matches(const QHttpServerRequest &request,
                          QRegularExpressionMatch *match) const;
 
-    virtual QIODevice* createBodyDevice(const QRegularExpressionMatch& match);
+    virtual QIODevice* createBodyDevice(const QHttpServerRequest &request, const QRegularExpressionMatch& match);
 
     QHttpServerRouterRule(QHttpServerRouterRulePrivate *d);
 

--- a/src/src.pro
+++ b/src/src.pro
@@ -1,4 +1,11 @@
 TEMPLATE = subdirs
 
+QT = network
+
 SUBDIRS = \
     httpserver
+
+qtConfig(ssl) {
+    SUBDIRS += sslserver
+    httpserver.depends = sslserver
+}

--- a/src/sslserver/qsslserver.cpp
+++ b/src/sslserver/qsslserver.cpp
@@ -54,8 +54,6 @@ void QSslServer::incomingConnection(qintptr handle)
     QSslSocket *socket = new QSslSocket(this);
     connect(socket, QOverload<const QList<QSslError>&>::of(&QSslSocket::sslErrors),
             [this, socket](const QList<QSslError> &errors) {
-        for (auto &err: errors)
-            qCCritical(lcSS) << err;
         Q_EMIT sslErrors(socket, errors);
     });
     socket->setSocketDescriptor(handle);

--- a/src/sslserver/qsslserver.h
+++ b/src/sslserver/qsslserver.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 **
-** Copyright (C) 2019 The Qt Company Ltd.
+** Copyright (C) 2019 Sylvain Garcia <garcia.6l20@gmail.com>.
 ** Contact: https://www.qt.io/licensing/
 **
 ** This file is part of the QtHttpServer module of the Qt Toolkit.
@@ -27,56 +27,36 @@
 **
 ****************************************************************************/
 
-#ifndef QABSTRACTHTTPSERVER_P_H
-#define QABSTRACTHTTPSERVER_P_H
+#ifndef QSSLSERVER_H
+#define QSSLSERVER_H
 
-//
-//  W A R N I N G
-//  -------------
-//
-// This file is not part of the Qt API.  It exists for the convenience
-// of QHttpServer. This header file may change from version to
-// version without notice, or even be removed.
-//
-// We mean it.
+#include <QtSslServer/qtsslserverglobal.h>
 
-#include <QtHttpServer/qabstracthttpserver.h>
-#include <QtHttpServer/qthttpserverglobal.h>
-
-#include <private/qobject_p.h>
-
-#if defined(QT_WEBSOCKETS_LIB)
-#include <QtWebSockets/qwebsocketserver.h>
-#endif // defined(QT_WEBSOCKETS_LIB)
+#include <QtNetwork/qtcpserver.h>
+#include <QtNetwork/qsslconfiguration.h>
 
 QT_BEGIN_NAMESPACE
 
-class QHttpServerRequest;
-
-class Q_HTTPSERVER_EXPORT QAbstractHttpServerPrivate: public QObjectPrivate
+class QSslServerPrivate;
+class Q_SSLSERVER_EXPORT QSslServer : public QTcpServer
 {
-    Q_DECLARE_PUBLIC(QAbstractHttpServer)
-
+    Q_OBJECT
 public:
-    QAbstractHttpServerPrivate();
+    QSslServer(QObject *parent = nullptr);
+    QSslServer(const QSslConfiguration &sslConfiguration, QObject *parent = nullptr);
 
-#if defined(QT_WEBSOCKETS_LIB)
-    QWebSocketServer websocketServer {
-        QLatin1String("QtHttpServer"),
-        QWebSocketServer::NonSecureMode
-    };
-#endif // defined(QT_WEBSOCKETS_LIB)
+    void setSslConfiguration(const QSslConfiguration &sslConfiguration);
 
-    void handleNewConnections();
-    void handleReadyRead(QTcpSocket *socket,
-                         QHttpServerRequest *request);
+Q_SIGNALS:
+    void sslErrors(QSslSocket *socket, const QList<QSslError> &errors);
 
-#if QT_CONFIG(ssl)
-    QSslConfiguration sslConfiguration;
-    bool sslEnabled = false;
-#endif
+protected:
+    void incomingConnection(qintptr handle) override final;
+
+private:
+    Q_DECLARE_PRIVATE(QSslServer)
 };
 
 QT_END_NAMESPACE
 
-#endif // QABSTRACTHTTPSERVER_P_H
+#endif // QSSLSERVER_HPP

--- a/src/sslserver/qsslserver_p.h
+++ b/src/sslserver/qsslserver_p.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 **
-** Copyright (C) 2019 The Qt Company Ltd.
+** Copyright (C) 2019 Sylvain Garcia <garcia.6l20@gmail.com>.
 ** Contact: https://www.qt.io/licensing/
 **
 ** This file is part of the QtHttpServer module of the Qt Toolkit.
@@ -27,56 +27,20 @@
 **
 ****************************************************************************/
 
-#ifndef QABSTRACTHTTPSERVER_P_H
-#define QABSTRACTHTTPSERVER_P_H
+#ifndef QSSLSERVER_P_H
+#define QSSLSERVER_P_H
 
-//
-//  W A R N I N G
-//  -------------
-//
-// This file is not part of the Qt API.  It exists for the convenience
-// of QHttpServer. This header file may change from version to
-// version without notice, or even be removed.
-//
-// We mean it.
+#include <QtSslServer/qsslserver.h>
 
-#include <QtHttpServer/qabstracthttpserver.h>
-#include <QtHttpServer/qthttpserverglobal.h>
-
-#include <private/qobject_p.h>
-
-#if defined(QT_WEBSOCKETS_LIB)
-#include <QtWebSockets/qwebsocketserver.h>
-#endif // defined(QT_WEBSOCKETS_LIB)
+#include <private/qtcpserver_p.h>
 
 QT_BEGIN_NAMESPACE
 
-class QHttpServerRequest;
-
-class Q_HTTPSERVER_EXPORT QAbstractHttpServerPrivate: public QObjectPrivate
-{
-    Q_DECLARE_PUBLIC(QAbstractHttpServer)
-
+class QSslServerPrivate: public QTcpServerPrivate {
 public:
-    QAbstractHttpServerPrivate();
-
-#if defined(QT_WEBSOCKETS_LIB)
-    QWebSocketServer websocketServer {
-        QLatin1String("QtHttpServer"),
-        QWebSocketServer::NonSecureMode
-    };
-#endif // defined(QT_WEBSOCKETS_LIB)
-
-    void handleNewConnections();
-    void handleReadyRead(QTcpSocket *socket,
-                         QHttpServerRequest *request);
-
-#if QT_CONFIG(ssl)
     QSslConfiguration sslConfiguration;
-    bool sslEnabled = false;
-#endif
 };
 
 QT_END_NAMESPACE
 
-#endif // QABSTRACTHTTPSERVER_P_H
+#endif // QSSLSERVER_P_H

--- a/src/sslserver/qtsslserverglobal.h
+++ b/src/sslserver/qtsslserverglobal.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 **
-** Copyright (C) 2019 The Qt Company Ltd.
+** Copyright (C) 2019 Sylvain Garcia <garcia.6l20@gmail.com>.
 ** Contact: https://www.qt.io/licensing/
 **
 ** This file is part of the QtHttpServer module of the Qt Toolkit.
@@ -27,56 +27,23 @@
 **
 ****************************************************************************/
 
-#ifndef QABSTRACTHTTPSERVER_P_H
-#define QABSTRACTHTTPSERVER_P_H
+#ifndef QTSSLSERVERGLOBAL_H
+#define QTSSLSERVERGLOBAL_H
 
-//
-//  W A R N I N G
-//  -------------
-//
-// This file is not part of the Qt API.  It exists for the convenience
-// of QHttpServer. This header file may change from version to
-// version without notice, or even be removed.
-//
-// We mean it.
-
-#include <QtHttpServer/qabstracthttpserver.h>
-#include <QtHttpServer/qthttpserverglobal.h>
-
-#include <private/qobject_p.h>
-
-#if defined(QT_WEBSOCKETS_LIB)
-#include <QtWebSockets/qwebsocketserver.h>
-#endif // defined(QT_WEBSOCKETS_LIB)
+#include <QtCore/qglobal.h>
 
 QT_BEGIN_NAMESPACE
 
-class QHttpServerRequest;
-
-class Q_HTTPSERVER_EXPORT QAbstractHttpServerPrivate: public QObjectPrivate
-{
-    Q_DECLARE_PUBLIC(QAbstractHttpServer)
-
-public:
-    QAbstractHttpServerPrivate();
-
-#if defined(QT_WEBSOCKETS_LIB)
-    QWebSocketServer websocketServer {
-        QLatin1String("QtHttpServer"),
-        QWebSocketServer::NonSecureMode
-    };
-#endif // defined(QT_WEBSOCKETS_LIB)
-
-    void handleNewConnections();
-    void handleReadyRead(QTcpSocket *socket,
-                         QHttpServerRequest *request);
-
-#if QT_CONFIG(ssl)
-    QSslConfiguration sslConfiguration;
-    bool sslEnabled = false;
+#ifndef QT_STATIC
+#  if defined(QT_BUILD_SSLSERVER_LIB)
+#    define Q_SSLSERVER_EXPORT Q_DECL_EXPORT
+#  else
+#    define Q_SSLSERVER_EXPORT Q_DECL_IMPORT
+#  endif
+#else
+#  define Q_SSLSERVER_EXPORT
 #endif
-};
 
 QT_END_NAMESPACE
 
-#endif // QABSTRACTHTTPSERVER_P_H
+#endif // QTSSLSERVERGLOBAL_H

--- a/src/sslserver/sslserver.pro
+++ b/src/sslserver/sslserver.pro
@@ -1,0 +1,14 @@
+TARGET = QtSslServer
+INCLUDEPATH += .
+
+QT = network network-private core-private
+
+HEADERS += \
+    qsslserver.h \
+    qtsslserverglobal.h \
+    qsslserver_p.h
+
+SOURCES += \
+    qsslserver.cpp
+
+load(qt_module)

--- a/sync.profile
+++ b/sync.profile
@@ -1,3 +1,4 @@
 %modules = ( # path to module name map
     "QtHttpServer" => "$basedir/src/httpserver",
+    "QtSslServer" => "$basedir/src/sslserver",
 );

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,3 @@
+enable_testing()
+
+add_subdirectory(auto)

--- a/tests/auto/CMakeLists.txt
+++ b/tests/auto/CMakeLists.txt
@@ -1,0 +1,10 @@
+find_package(Qt5 COMPONENTS Test REQUIRED)
+
+# auto link subfolders to Qt5::Test and Qt5::HttpServer
+link_libraries(Qt5::Test Qt5::HttpServer)
+
+add_subdirectory(qabstracthttpserver)
+add_subdirectory(qhttpserver)
+add_subdirectory(qhttpserverresponder)
+add_subdirectory(qhttpserverresponse)
+add_subdirectory(qhttpserverrouter)

--- a/tests/auto/auto.pro
+++ b/tests/auto/auto.pro
@@ -1,5 +1,7 @@
 TEMPLATE = subdirs
 
+QT = network
+
 SUBDIRS = \
     cmake \
     qabstracthttpserver \

--- a/tests/auto/qabstracthttpserver/CMakeLists.txt
+++ b/tests/auto/qabstracthttpserver/CMakeLists.txt
@@ -1,0 +1,2 @@
+set(_test qabstracthttpserver)
+add_executable(${PROJECT_NAME}_${_test}_test tst_${_test}.cpp)

--- a/tests/auto/qhttpserver/CMakeLists.txt
+++ b/tests/auto/qhttpserver/CMakeLists.txt
@@ -1,0 +1,2 @@
+set(_test qhttpserver)
+add_executable(${PROJECT_NAME}_${_test}_test tst_${_test}.cpp)

--- a/tests/auto/qhttpserver/tst_qhttpserver.cpp
+++ b/tests/auto/qhttpserver/tst_qhttpserver.cpp
@@ -91,6 +91,7 @@ private slots:
     void routePost();
     void routeDelete_data();
     void routeDelete();
+    void routeExtraHeaders();
     void invalidRouterArguments();
     void checkRouteLambdaCapture();
 
@@ -233,6 +234,13 @@ void tst_QHttpServer::initTestCase()
         writeChunk("part 1 of the message, ");
         writeChunk("part 2 of the message");
         writeChunk("");
+    });
+
+    httpserver.route("/extra-headers", [] () {
+        QHttpServerResponse resp("");
+        resp.setHeader("Content-Type", "application/x-empty");
+        resp.setHeader("Server", "test server");
+        return resp;
     });
 
     urlBase = QStringLiteral("http://localhost:%1%2").arg(httpserver.listen());
@@ -596,6 +604,19 @@ void tst_QHttpServer::routeDelete()
 
     QCOMPARE(reply->header(QNetworkRequest::ContentTypeHeader), type);
     QCOMPARE(reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt(), code);
+}
+
+void tst_QHttpServer::routeExtraHeaders()
+{
+    QNetworkAccessManager networkAccessManager;
+    const QUrl requestUrl(urlBase.arg("/extra-headers"));
+    auto reply = networkAccessManager.get(QNetworkRequest(requestUrl));
+
+    QTRY_VERIFY(reply->isFinished());
+
+    QCOMPARE(reply->header(QNetworkRequest::ContentTypeHeader), "application/x-empty");
+    QCOMPARE(reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt(), 200);
+    QCOMPARE(reply->header(QNetworkRequest::ServerHeader), "test server");
 }
 
 struct CustomType {

--- a/tests/auto/qhttpserver/tst_qhttpserver.cpp
+++ b/tests/auto/qhttpserver/tst_qhttpserver.cpp
@@ -51,6 +51,41 @@
 #include <QtNetwork/qnetworkreply.h>
 #include <QtNetwork/qnetworkrequest.h>
 
+
+static const char g_privateKey[] = R"(-----BEGIN RSA PRIVATE KEY-----
+MIICXQIBAAKBgQDykG51ZjNJra8iS27g3DJojH1qG8C3Z+Avo5U6Qz6NkOsjvr22
+gXqOS4uwVUXdCAKxsP0Wwn2zGz5vxGpLPVKtbAmaqHYZuipMG/Qun3t+QYBgR+9t
+lmHdI8TNP2Om8stDO5uQyBH7DcMjPyIgpfc8fBoNLhCn4oC2n6JK9EMuhQIDAQAB
+AoGAUHTLzrEJjgTINI3kxz0Ck18WMl3mPG9+Ew8lbl/jnb1V4VNhReoIpq40NVbz
+h28ixaG5MRVt8Dy3Jwd1YmOCylHSujdFQ2u0pcHFmERgDS2bOMwMTRoFOj2qgMGS
+9SM+iXlPY5AQY8nEg7rLjMSfaC/8Hq4RXpkj4PeHh6N7AzkCQQD++HzM3xBr+Gvh
+zco9Kt8IiKNlfeiA5gUQq1UPJzcWIEgW1Tgr5UzMUOcZ0HfYwhqL3+wMhzN4sba+
+1plB1QRXAkEA84sfM0jm9BRSqtYTPlhsYAmuPjeo24Pxel8ijEkToAu0ppEC6AQ3
+zfwZD0ISgaWQ7af5TN/RCsoNVX79twP6gwJBANbtB+Z6shERm38ARdZB6Tf8ViAb
+fn4JZ4OhqVXYrKrOE3aLzYnTBGXGXMh53kytcksuOoBlB5JZ274Kj63arokCQFPo
+9xMAZzJpXiImJ/MvHAfqzfH501/ukeCLrqeO9ggKgG9zPwEZkvCRj0DGjwHEPa7k
+VOy7oJaLDxUJ7/iCkmkCQQCtTLsvDbGH4tyFK5VIPJbUcccIib+dTzSTeONdUxKL
+Yk+C6o7OpaUWX+ikp4Ow/6iHOAgXaeA2OolDer/NspUy
+-----END RSA PRIVATE KEY-----)";
+
+static const char g_certificate[] = R"(-----BEGIN CERTIFICATE-----
+MIICrjCCAhegAwIBAgIUcuXjCSkJ2+v/Rqv/UHThTRGFlpswDQYJKoZIhvcNAQEL
+BQAwaDELMAkGA1UEBhMCRlIxDzANBgNVBAgMBkZyYW5jZTERMA8GA1UEBwwIR3Jl
+bm9ibGUxFjAUBgNVBAoMDVF0Q29udHJpYnV0b3IxHTAbBgNVBAMMFHFodHRwc3Nl
+cnZlcnRlc3QuY29tMCAXDTE5MDkyNjA4NTc1MloYDzIyNTUwMzEzMDg1NzUyWjBo
+MQswCQYDVQQGEwJGUjEPMA0GA1UECAwGRnJhbmNlMREwDwYDVQQHDAhHcmVub2Js
+ZTEWMBQGA1UECgwNUXRDb250cmlidXRvcjEdMBsGA1UEAwwUcWh0dHBzc2VydmVy
+dGVzdC5jb20wgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBAPKQbnVmM0mtryJL
+buDcMmiMfWobwLdn4C+jlTpDPo2Q6yO+vbaBeo5Li7BVRd0IArGw/RbCfbMbPm/E
+aks9Uq1sCZqodhm6Kkwb9C6fe35BgGBH722WYd0jxM0/Y6byy0M7m5DIEfsNwyM/
+IiCl9zx8Gg0uEKfigLafokr0Qy6FAgMBAAGjUzBRMB0GA1UdDgQWBBTDMYCcl2jz
+UUWByEzTj5Ew/LWkeDAfBgNVHSMEGDAWgBTDMYCcl2jzUUWByEzTj5Ew/LWkeDAP
+BgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4GBAMNupAOXoBih6RvuAn3w
+W8jOIZfkn5CMYdbUSndY/Wrt4p07M8r9uFPWG4bXSwG6n9Nzl75X9b0ka/jqPjQ3
+X769simPygCblBp2xwE6w14aHEBx4kcF1p2QbC1vHynszJxyVLvHqUjuJwVAoPrM
+Imy6LOiw2tRTHPsj7UH16M6C
+-----END CERTIFICATE-----)";
+
 QT_BEGIN_NAMESPACE
 
 class QueryRequireRouterRule : public QHttpServerRouterRule
@@ -101,6 +136,8 @@ private:
 private:
     QHttpServer httpserver;
     QString urlBase;
+    QString sslUrlBase;
+    QNetworkAccessManager networkAccessManager;
 };
 
 struct CustomArg {
@@ -243,7 +280,52 @@ void tst_QHttpServer::initTestCase()
         return resp;
     });
 
-    urlBase = QStringLiteral("http://localhost:%1%2").arg(httpserver.listen());
+    int port = httpserver.listen();
+    if (port < 0)
+        qCritical() << "Http server listen failed";
+
+    urlBase = QStringLiteral("http://localhost:%1%2").arg(port);
+
+#if QT_CONFIG(ssl)
+    httpserver.sslSetup(QSslCertificate(g_certificate),
+                        QSslKey(g_privateKey, QSsl::Rsa));
+
+    port = httpserver.listen();
+    if (port < 0)
+        qCritical() << "Http server listen failed";
+
+    sslUrlBase = QStringLiteral("https://localhost:%1%2").arg(port);
+
+    QList<QSslError> expectedSslErrors;
+
+// Non-OpenSSL backends are not able to report a specific error code
+// for self-signed certificates.
+#ifndef QT_NO_OPENSSL
+# define FLUKE_CERTIFICATE_ERROR QSslError::SelfSignedCertificate
+#else
+# define FLUKE_CERTIFICATE_ERROR QSslError::CertificateUntrusted
+#endif
+
+    expectedSslErrors.append(QSslError(FLUKE_CERTIFICATE_ERROR,
+                                       QSslCertificate(g_certificate)));
+    expectedSslErrors.append(QSslError(QSslError::HostNameMismatch,
+                                       QSslCertificate(g_certificate)));
+
+    connect(&networkAccessManager, &QNetworkAccessManager::sslErrors,
+            [expectedSslErrors](QNetworkReply *reply,
+                                const QList<QSslError> &errors) {
+        for (const auto &error: errors) {
+            for (const auto &expectedError: expectedSslErrors) {
+                if (error.error() != expectedError.error() ||
+                    error.certificate() != expectedError.certificate()) {
+                    qCritical() << "Got unexpected ssl error:"
+                                << error << error.certificate();
+                }
+            }
+        }
+        reply->ignoreSslErrors(expectedSslErrors);
+    });
+#endif
 }
 
 void tst_QHttpServer::routeGet_data()
@@ -254,177 +336,207 @@ void tst_QHttpServer::routeGet_data()
     QTest::addColumn<QString>("body");
 
     QTest::addRow("hello world")
-        << "/"
+        << urlBase.arg("/")
         << 200
         << "text/plain"
         << "Hello world get";
 
     QTest::addRow("test msg")
-        << "/test"
+        << urlBase.arg("/test")
         << 200
         << "text/html"
         << "test msg";
 
     QTest::addRow("not found")
-        << "/not-found"
+        << urlBase.arg("/not-found")
         << 404
         << "application/x-empty"
         << "";
 
     QTest::addRow("arg:int")
-        << "/page/10"
+        << urlBase.arg("/page/10")
         << 200
         << "text/plain"
         << "page: 10";
 
     QTest::addRow("arg:-int")
-        << "/page/-10"
+        << urlBase.arg("/page/-10")
         << 200
         << "text/plain"
         << "page: -10";
 
     QTest::addRow("arg:uint")
-        << "/page/10/detail"
+        << urlBase.arg("/page/10/detail")
         << 200
         << "text/plain"
         << "page: 10 detail";
 
     QTest::addRow("arg:-uint")
-        << "/page/-10/detail"
+        << urlBase.arg("/page/-10/detail")
         << 404
         << "application/x-empty"
         << "";
 
     QTest::addRow("arg:string")
-        << "/user/test"
+        << urlBase.arg("/user/test")
         << 200
         << "text/plain"
         << "test";
 
     QTest::addRow("arg:string")
-        << "/user/test test ,!a+."
+        << urlBase.arg("/user/test test ,!a+.")
         << 200
         << "text/plain"
         << "test test ,!a+.";
 
     QTest::addRow("arg:string,ba")
-        << "/user/james/bond"
+        << urlBase.arg("/user/james/bond")
         << 200
         << "text/plain"
         << "james-bond";
 
     QTest::addRow("arg:url")
-        << "/test/api/v0/cmds?val=1"
+        << urlBase.arg("/test/api/v0/cmds?val=1")
         << 200
         << "text/plain"
         << "path: api/v0/cmds";
 
     QTest::addRow("arg:float 5.1")
-        << "/api/v5.1"
+        << urlBase.arg("/api/v5.1")
         << 200
         << "text/plain"
         << "api 5.1v";
 
     QTest::addRow("arg:float 5.")
-        << "/api/v5."
+        << urlBase.arg("/api/v5.")
         << 200
         << "text/plain"
         << "api 5v";
 
     QTest::addRow("arg:float 6.0")
-        << "/api/v6.0"
+        << urlBase.arg("/api/v6.0")
         << 200
         << "text/plain"
         << "api 6v";
 
     QTest::addRow("arg:float,uint")
-        << "/api/v5.1/user/10"
+        << urlBase.arg("/api/v5.1/user/10")
         << 200
         << "text/plain"
         << "api 5.1v, user id - 10";
 
     QTest::addRow("arg:float,uint,query")
-        << "/api/v5.2/user/11/settings?role=admin" << 200
+        << urlBase.arg("/api/v5.2/user/11/settings?role=admin")
+        << 200
         << "text/plain"
         << "api 5.2v, user id - 11, set settings role=admin#''";
 
     // The fragment isn't actually sent via HTTP (it's information for the user agent)
     QTest::addRow("arg:float,uint, query+fragment")
-        << "/api/v5.2/user/11/settings?role=admin#tag"
-        << 200 << "text/plain"
+        << urlBase.arg("/api/v5.2/user/11/settings?role=admin#tag")
+        << 200
+        << "text/plain"
         << "api 5.2v, user id - 11, set settings role=admin#''";
 
     QTest::addRow("custom route rule")
-        << "/custom/15"
+        << urlBase.arg("/custom/15")
         << 404
         << "application/x-empty"
         << "";
 
     QTest::addRow("custom route rule + query")
-        << "/custom/10?key=11&g=1"
+        << urlBase.arg("/custom/10?key=11&g=1")
         << 200
         << "text/plain"
         << "Custom router rule: 10, key=11";
 
     QTest::addRow("custom route rule + query key req")
-        << "/custom/10?g=1&key=12"
+        << urlBase.arg("/custom/10?g=1&key=12")
         << 200
         << "text/plain"
         << "Custom router rule: 10, key=12";
 
     QTest::addRow("post-and-get, get")
-        << "/post-and-get"
+        << urlBase.arg("/post-and-get")
         << 200
         << "text/plain"
         << "Hello world get";
 
     QTest::addRow("invalid-rule-method, get")
-        << "/invalid-rule-method"
+        << urlBase.arg("/invalid-rule-method")
         << 404
         << "application/x-empty"
         << "";
 
     QTest::addRow("check custom type, data=1")
-        << "/check-custom-type/1"
+        << urlBase.arg("/check-custom-type/1")
         << 200
         << "text/plain"
         << "data = 1";
 
     QTest::addRow("any, get")
-        << "/any"
+        << urlBase.arg("/any")
         << 200
         << "text/plain"
         << "Get";
 
     QTest::addRow("response from html file")
-        << "/file/text.html"
+        << urlBase.arg("/file/text.html")
         << 200
         << "text/html"
         << "<html></html>";
 
     QTest::addRow("response from json file")
-        << "/file/application.json"
+        << urlBase.arg("/file/application.json")
         << 200
         << "application/json"
         << "{ \"key\": \"value\" }";
 
     QTest::addRow("json-object")
-        << "/json-object/"
+        << urlBase.arg("/json-object/")
         << 200
         << "application/json"
         << "{\"property\":\"test\",\"value\":1}";
 
     QTest::addRow("json-array")
-        << "/json-array/"
+        << urlBase.arg("/json-array/")
         << 200
         << "application/json"
         << "[1,\"2\",{\"name\":\"test\"}]";
 
     QTest::addRow("chunked")
-        << "/chunked/"
+        << urlBase.arg("/chunked/")
         << 200
         << "text/plain"
         << "part 1 of the message, part 2 of the message";
+
+#if QT_CONFIG(ssl)
+
+    QTest::addRow("hello world, ssl")
+        << sslUrlBase.arg("/")
+        << 200
+        << "text/plain"
+        << "Hello world get";
+
+    QTest::addRow("post-and-get, get, ssl")
+        << sslUrlBase.arg("/post-and-get")
+        << 200
+        << "text/plain"
+        << "Hello world get";
+
+    QTest::addRow("invalid-rule-method, get, ssl")
+        << sslUrlBase.arg("/invalid-rule-method")
+        << 404
+        << "application/x-empty"
+        << "";
+
+    QTest::addRow("check custom type, data=1, ssl")
+        << sslUrlBase.arg("/check-custom-type/1")
+        << 200
+        << "text/plain"
+        << "data = 1";
+
+#endif // QT_CONFIG(ssl)
 }
 
 void tst_QHttpServer::routeGet()
@@ -434,15 +546,15 @@ void tst_QHttpServer::routeGet()
     QFETCH(QString, type);
     QFETCH(QString, body);
 
-    QNetworkAccessManager networkAccessManager;
-    const QUrl requestUrl(urlBase.arg(url));
-    auto reply = networkAccessManager.get(QNetworkRequest(requestUrl));
+    auto reply = networkAccessManager.get(QNetworkRequest(url));
 
     QTRY_VERIFY(reply->isFinished());
 
     QCOMPARE(reply->header(QNetworkRequest::ContentTypeHeader), type);
     QCOMPARE(reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt(), code);
     QCOMPARE(reply->readAll().trimmed(), body);
+
+    reply->deleteLater();
 }
 
 void tst_QHttpServer::routeKeepAlive()
@@ -458,7 +570,6 @@ void tst_QHttpServer::routeKeepAlive()
             .arg(static_cast<int>(req.method()));
     });
 
-    QNetworkAccessManager networkAccessManager;
     QNetworkRequest request(urlBase.arg("/keep-alive"));
     request.setRawHeader(QByteArray("Connection"), QByteArray("keep-alive"));
 
@@ -506,28 +617,28 @@ void tst_QHttpServer::routePost_data()
     QTest::addColumn<QString>("body");
 
     QTest::addRow("hello world")
-        << "/"
+        << urlBase.arg("/")
         << 200
         << "text/plain"
         << ""
         << "Hello world post";
 
     QTest::addRow("post-and-get, post")
-        << "/post-and-get"
+        << urlBase.arg("/post-and-get")
         << 200
         << "text/plain"
         << ""
         << "Hello world post";
 
     QTest::addRow("any, post")
-        << "/any"
+        << urlBase.arg("/any")
         << 200
         << "text/plain"
         << ""
         << "Post";
 
     QTest::addRow("post-body")
-        << "/post-body"
+        << urlBase.arg("/post-body")
         << 200
         << "text/plain"
         << "some post data"
@@ -538,11 +649,43 @@ void tst_QHttpServer::routePost_data()
         body.append(QString::number(i));
 
     QTest::addRow("post-body - huge body, chunk test")
-        << "/post-body"
+        << urlBase.arg("/post-body")
         << 200
         << "text/plain"
         << body
         << body;
+
+#if QT_CONFIG(ssl)
+
+    QTest::addRow("post-and-get, post, ssl")
+        << sslUrlBase.arg("/post-and-get")
+        << 200
+        << "text/plain"
+        << ""
+        << "Hello world post";
+
+    QTest::addRow("any, post, ssl")
+        << sslUrlBase.arg("/any")
+        << 200
+        << "text/plain"
+        << ""
+        << "Post";
+
+    QTest::addRow("post-body, ssl")
+        << sslUrlBase.arg("/post-body")
+        << 200
+        << "text/plain"
+        << "some post data"
+        << "some post data";
+
+    QTest::addRow("post-body - huge body, chunk test, ssl")
+        << sslUrlBase.arg("/post-body")
+        << 200
+        << "text/plain"
+        << body
+        << body;
+
+#endif // QT_CONFIG(ssl)
 }
 
 void tst_QHttpServer::routePost()
@@ -553,8 +696,7 @@ void tst_QHttpServer::routePost()
     QFETCH(QString, data);
     QFETCH(QString, body);
 
-    QNetworkAccessManager networkAccessManager;
-    QNetworkRequest request(QUrl(urlBase.arg(url)));
+    QNetworkRequest request(url);
     if (data.size()) {
         request.setHeader(QNetworkRequest::ContentTypeHeader,
                           QHttpServerLiterals::contentTypeTextHtml());
@@ -567,6 +709,8 @@ void tst_QHttpServer::routePost()
     QCOMPARE(reply->header(QNetworkRequest::ContentTypeHeader), type);
     QCOMPARE(reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt(), code);
     QCOMPARE(reply->readAll(), body);
+
+    reply->deleteLater();
 }
 
 void tst_QHttpServer::routeDelete_data()
@@ -577,16 +721,32 @@ void tst_QHttpServer::routeDelete_data()
     QTest::addColumn<QString>("data");
 
     QTest::addRow("post-and-get, delete")
-        << "/post-and-get"
+        << urlBase.arg("/post-and-get")
         << 404
         << "application/x-empty"
         << "";
 
     QTest::addRow("any, delete")
-        << "/any"
+        << urlBase.arg("/any")
         << 200
         << "text/plain"
         << "Delete";
+
+#if QT_CONFIG(ssl)
+
+    QTest::addRow("post-and-get, delete, ssl")
+        << sslUrlBase.arg("/post-and-get")
+        << 404
+        << "application/x-empty"
+        << "";
+
+    QTest::addRow("any, delete, ssl")
+        << sslUrlBase.arg("/any")
+        << 200
+        << "text/plain"
+        << "Delete";
+
+#endif // QT_CONFIG(ssl)
 }
 
 void tst_QHttpServer::routeDelete()
@@ -596,19 +756,18 @@ void tst_QHttpServer::routeDelete()
     QFETCH(QString, type);
     QFETCH(QString, data);
 
-    QNetworkAccessManager networkAccessManager;
-    const QUrl requestUrl(urlBase.arg(url));
-    auto reply = networkAccessManager.deleteResource(QNetworkRequest(requestUrl));
+    auto reply = networkAccessManager.deleteResource(QNetworkRequest(url));
 
     QTRY_VERIFY(reply->isFinished());
 
     QCOMPARE(reply->header(QNetworkRequest::ContentTypeHeader), type);
     QCOMPARE(reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt(), code);
+
+    reply->deleteLater();
 }
 
 void tst_QHttpServer::routeExtraHeaders()
 {
-    QNetworkAccessManager networkAccessManager;
     const QUrl requestUrl(urlBase.arg("/extra-headers"));
     auto reply = networkAccessManager.get(QNetworkRequest(requestUrl));
 
@@ -669,8 +828,8 @@ void tst_QHttpServer::checkRouteLambdaCapture()
         return msg;
     });
 
-    QNetworkAccessManager networkAccessManager;
-    checkReply(networkAccessManager.get(QNetworkRequest(QUrl(urlBase.arg("/capture-this/")))),
+    checkReply(networkAccessManager.get(
+                   QNetworkRequest(QUrl(urlBase.arg("/capture-this/")))),
                urlBase);
     if (QTest::currentTestFailed())
         return;
@@ -688,6 +847,8 @@ void tst_QHttpServer::checkReply(QNetworkReply *reply, const QString &response) 
     QCOMPARE(reply->header(QNetworkRequest::ContentTypeHeader), "text/plain");
     QCOMPARE(reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt(), 200);
     QCOMPARE(reply->readAll(), response);
+
+    reply->deleteLater();
 };
 
 QT_END_NAMESPACE

--- a/tests/auto/qhttpserver/tst_qhttpserver.cpp
+++ b/tests/auto/qhttpserver/tst_qhttpserver.cpp
@@ -127,6 +127,8 @@ private slots:
     void routeDelete_data();
     void routeDelete();
     void routeExtraHeaders();
+    void routeDirectUpload_data();
+    void routeDirectUpload();
     void invalidRouterArguments();
     void checkRouteLambdaCapture();
 
@@ -143,7 +145,7 @@ private:
 struct CustomArg {
     int data = 10;
 
-    CustomArg() {} ;
+    CustomArg() {}
     CustomArg(const QString &urlArg) : data(urlArg.toInt()) {}
 };
 
@@ -271,6 +273,12 @@ void tst_QHttpServer::initTestCase()
         writeChunk("part 1 of the message, ");
         writeChunk("part 2 of the message");
         writeChunk("");
+    });
+
+    httpserver.route<DirectFileAccessRouterRule>("/direct-upload/<arg>", [] (const QString& filename, const QHttpServerRequest& request) {
+        request.bodyDevice()->close(); // need to close the device before the request is being destroyed
+        qDebug() << filename << "uploaded !";
+        return QHttpServerResponse("text/plain", "ok", QHttpServerResponse::StatusCode::Ok);
     });
 
     httpserver.route("/extra-headers", [] () {
@@ -776,6 +784,61 @@ void tst_QHttpServer::routeExtraHeaders()
     QCOMPARE(reply->header(QNetworkRequest::ContentTypeHeader), "application/x-empty");
     QCOMPARE(reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt(), 200);
     QCOMPARE(reply->header(QNetworkRequest::ServerHeader), "test server");
+}
+
+
+void tst_QHttpServer::routeDirectUpload_data()
+{
+    QTest::addColumn<QString>("url");
+    QTest::addColumn<int>("code");
+    QTest::addColumn<QString>("type");
+    QTest::addColumn<QString>("data");
+    QTest::addColumn<QString>("filename");
+
+    QTest::addRow("post, short")
+        << "/direct-upload"
+        << 200
+        << "text/plain"
+        << "Hello QHttpServer !!!"
+        << "direct-upload-short.txt";
+
+    QString body;
+    for (int i = 0; i < 10000; i++)
+        body.append(QString::number(i));
+
+    QTest::addRow("post - huge body")
+        << "/direct-upload"
+        << 200
+        << "text/plain"
+        << body
+        << "direct-upload-huge.txt";
+}
+
+void tst_QHttpServer::routeDirectUpload()
+{
+    QFETCH(QString, url);
+    QFETCH(int, code);
+    QFETCH(QString, type);
+    QFETCH(QString, data);
+    QFETCH(QString, filename);
+
+    QNetworkAccessManager networkAccessManager;
+    QNetworkRequest request(QUrl(urlBase.arg(url) + "/" + filename));
+    if (data.size())
+        request.setHeader(QNetworkRequest::ContentTypeHeader, "text/html");
+
+    auto reply = networkAccessManager.post(request, data.toUtf8());
+
+    QTRY_VERIFY(reply->isFinished());
+
+    QCOMPARE(reply->header(QNetworkRequest::ContentTypeHeader), type);
+    QCOMPARE(reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt(), code);
+
+    QFile uploaded_file(filename);
+    uploaded_file.open(QIODevice::ReadOnly);
+    QCOMPARE(data, uploaded_file.readAll());
+    uploaded_file.close();
+    uploaded_file.remove();
 }
 
 struct CustomType {

--- a/tests/auto/qhttpserverresponder/CMakeLists.txt
+++ b/tests/auto/qhttpserverresponder/CMakeLists.txt
@@ -1,0 +1,2 @@
+set(_test qhttpserverresponder)
+add_executable(${PROJECT_NAME}_${_test}_test tst_${_test}.cpp)

--- a/tests/auto/qhttpserverresponse/CMakeLists.txt
+++ b/tests/auto/qhttpserverresponse/CMakeLists.txt
@@ -1,0 +1,2 @@
+set(_test qhttpserverresponse)
+add_executable(${PROJECT_NAME}_${_test}_test tst_${_test}.cpp)

--- a/tests/auto/qhttpserverrouter/CMakeLists.txt
+++ b/tests/auto/qhttpserverrouter/CMakeLists.txt
@@ -1,0 +1,2 @@
+set(_test qhttpserverrouter)
+add_executable(${PROJECT_NAME}_${_test}_test tst_${_test}.cpp)


### PR DESCRIPTION
This PR enables `QAbstractHttpServer` to handle `QIODevice` instead of `QByteArray` to manage its body.
This allow us to provide direct forwarding body data to any `QIODevice` (eg.: `QFile`)